### PR TITLE
修正示例服务器代码中的一处错误，此会导致微信服务器校验token失败。

### DIFF
--- a/example/server.php
+++ b/example/server.php
@@ -121,5 +121,10 @@
 
   }
 
-  $wechat = new MyWechat($token, $encodingAesKey, $appId, $debugMode);
+  $wechat = new MyWechat(array(
+      'token' => $token,
+      'aeskey' => $encodingAesKey,
+      'appid' => $appId,
+      'debug' => $debugMode
+  ));
   $wechat->run();


### PR DESCRIPTION
因为构造函数与调用时传入的参数不一致。